### PR TITLE
Make flux kubernetes namespace configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Example of usage:
 | k8s\_cluster\_name             | Cluster repository name       | `string` |            | True     |
 | flux\_bot\_username            | Username for Flux CD Git user | `string` | `flux-bot` | False    |
 | flux\_chart\_version           | Flux CD chart version         | `string` | `1.6.0`    | False    |
+| flux\_namespace                | Flux CD namespace             | `string` | `flux`     | False    |
 | helm\_operator\_chart\_version | Helm Operator chart version   | `string` | `1.2.0`    | False    |
 
 ## Output Values

--- a/flux.tf
+++ b/flux.tf
@@ -23,9 +23,9 @@ Example of usage:
 
 resource "kubernetes_namespace" "flux-ns" {
   metadata {
-    name = "flux"
+    name = var.flux_namespace
     labels = {
-      k8s-namespace = "flux"
+      k8s-namespace = var.flux_namespace
     }
   }
 }
@@ -34,7 +34,7 @@ resource "kubernetes_namespace" "flux-ns" {
 
 resource "kubernetes_secret" "flux-git-auth" {
   metadata {
-    namespace = "flux"
+    namespace = var.flux_namespace
     name      = "flux-git-auth"
   }
 
@@ -58,7 +58,7 @@ resource "helm_release" "flux" {
   repository   = "https://charts.fluxcd.io"
   chart        = "flux"
   version      = var.flux_chart_version
-  namespace    = "flux"
+  namespace    = var.flux_namespace
   reuse_values = "true"
 
   set {
@@ -118,7 +118,7 @@ resource "helm_release" "helm-operator" {
   repository   = "https://charts.fluxcd.io"
   chart        = "helm-operator"
   version      = var.helm_operator_chart_version
-  namespace    = "flux"
+  namespace    = var.flux_namespace
   reuse_values = "true"
 
   # Work with Helm v3 only

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable flux_chart_version {
   default     = "1.6.0"
 }
 
+variable flux_namespace {
+  description = "Flux CD kubernetes namespace"
+  type        = string
+  default     = "flux"
+}
+
 variable helm_operator_chart_version {
   description = "Helm Operator chart version"
   type        = string


### PR DESCRIPTION
Currently flux k8s namespace is hardcoded. Good idea would be make it configurable via variable.